### PR TITLE
Remove copy step for index.html in workflow

### DIFF
--- a/.github/workflows/frontend-pages.yml
+++ b/.github/workflows/frontend-pages.yml
@@ -43,9 +43,6 @@ jobs:
       - name: Build
         run: npm run build
 
-      - name: Copy index.html to 404.html
-        run: cp frontend/dist/index.html frontend/dist/404.html
-
       - name: Configure Pages
         uses: actions/configure-pages@v4
 


### PR DESCRIPTION
Removed step to copy index.html to 404.html in workflow.