### PR TITLE
Remove CNAME inclusion step from workflow

### DIFF
--- a/.github/workflows/frontend-pages.yml
+++ b/.github/workflows/frontend-pages.yml
@@ -49,9 +49,6 @@ jobs:
       - name: Build
         run: npm run build
 
-      - name: Include CNAME in artifact
-        run: cp CNAME dist/CNAME
-
       - name: Configure Pages
         uses: actions/configure-pages@v4
 


### PR DESCRIPTION
Removed step to include CNAME in the build artifact.